### PR TITLE
Fix min length parameter typo

### DIFF
--- a/_notebooks/2020-03-12-bart.ipynb
+++ b/_notebooks/2020-03-12-bart.ipynb
@@ -343,7 +343,7 @@
     "                             num_beams=4,\n",
     "                             length_penalty=2.0,\n",
     "                             max_length=142,\n",
-    "                             min_len=56,\n",
+    "                             min_length=56,\n",
     "                             no_repeat_ngram_size=3)\n",
     "\n",
     "summary_txt = tokenizer.decode(summary_ids.squeeze(), skip_special_tokens=True)\n",


### PR DESCRIPTION
Hi,

Thanks for your blog post! It was a short and fun read! There's a small typo in the `generate` function of the model. The parameter should be `min_length` instead of `min_len`.  